### PR TITLE
add option closeIfEmpty to annotation @Puppet

### DIFF
--- a/fragment-rigger/src/main/java/com/jkb/fragment/rigger/annotation/Puppet.java
+++ b/fragment-rigger/src/main/java/com/jkb/fragment/rigger/annotation/Puppet.java
@@ -54,4 +54,15 @@ public @interface Puppet {
    * @return The default value is false.
    */
   boolean stickyStack() default false;
+  
+  /**
+   * Allow or not exit the host {@link android.app.Activity}/{@link android.support.v4.app.Fragment} when
+   * the stack size = 0
+   *
+   * If the value is true , the host object(Activity/Fragment) will not be exit
+   * Otherwise , the host object(Activity/Fragment) will act as normal.
+   *
+   * @return The default value is true.
+   */
+  boolean closeIfEmpty() default true;
 }

--- a/fragment-rigger/src/main/java/com/jkb/fragment/rigger/rigger/_Rigger.java
+++ b/fragment-rigger/src/main/java/com/jkb/fragment/rigger/rigger/_Rigger.java
@@ -67,6 +67,7 @@ abstract class _Rigger implements IRigger {
   @IdRes
   private int mContainerViewId;
   private boolean mBindContainerView;
+  private boolean mCloseIfEmpty;
   RiggerTransaction mRiggerTransaction;
   FragmentStackManager mStackManager;
 
@@ -76,6 +77,7 @@ abstract class _Rigger implements IRigger {
     Class<?> clazz = mPuppetTarget.getClass();
     Puppet puppet = clazz.getAnnotation(Puppet.class);
     mBindContainerView = puppet.bondContainerView();
+    mCloseOnEmpty = puppet.closeIfEmpty();
     mContainerViewId = puppet.containerViewId();
     if (mContainerViewId <= 0) {
       try {
@@ -245,7 +247,10 @@ abstract class _Rigger implements IRigger {
     Logger.d(mPuppetTarget, "onRiggerBackPressed() method is called");
     String topFragmentTag = mStackManager.peek();
     if (TextUtils.isEmpty(topFragmentTag)) {
-      close();
+      if(mCloseIfEmpty) {
+        Logger.d(mPuppetTarget, "Rigger was closed because of empty top");
+        close();
+      }
     } else {
       //call the top fragment's onBackPressed method.
       Fragment topFragment = mRiggerTransaction.find(topFragmentTag);

--- a/fragment-rigger/src/main/java/com/jkb/fragment/rigger/rigger/_Rigger.java
+++ b/fragment-rigger/src/main/java/com/jkb/fragment/rigger/rigger/_Rigger.java
@@ -77,7 +77,7 @@ abstract class _Rigger implements IRigger {
     Class<?> clazz = mPuppetTarget.getClass();
     Puppet puppet = clazz.getAnnotation(Puppet.class);
     mBindContainerView = puppet.bondContainerView();
-    mCloseOnEmpty = puppet.closeIfEmpty();
+    mCloseIfEmpty = puppet.closeIfEmpty();
     mContainerViewId = puppet.containerViewId();
     if (mContainerViewId <= 0) {
       try {


### PR DESCRIPTION
in some case that using Rigger.addFragment() ( fragment not added in stack ) and show ( without re-init fragment )
when press back button it will close current activity that maybe unwanted action. So set `@Puppet(containerViewId = R.id.fragment_container, closeIfEmpty = false)` will solve that problem.